### PR TITLE
Fix issue with PATH separator character on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,17 +26,17 @@ specification.
 What does it look like?
 =======================
 
-.. image:: https://raw2.github.com/jakobwesthoff/phuml/master/images/phuml_example_thumbnail.jpg
+.. image:: https://raw.githubusercontent.com/jakobwesthoff/phuml/master/images/phuml_example_thumbnail.jpg
    :alt: Class diagram of the phUML generator
    :align: center
-   :target: https://raw2.github.com/jakobwesthoff/phuml/master/images/phuml_example.png
+   :target: https://raw.githubusercontent.com/jakobwesthoff/phuml/master/images/phuml_example.png
 
 The image shown here is the class diagramm which phUML created when run on
 its own codebase. This image is hardly readable, because it has been resized
 to fit in the layout of this page. You can take a look at the complete image
 by clicking here_
 
-.. _here: https://raw2.github.com/jakobwesthoff/phuml/master/images/phuml_example.png
+.. _here: https://raw.githubusercontent.com/jakobwesthoff/phuml/master/images/phuml_example.png
 
 
 Can I use this for my own projects?

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,7 +4,7 @@ define( "BASEDIR", dirname( __FILE__ ) . '/..' );
 
 ini_set(
     'include_path',
-    ini_get( "include_path" ) . ':' . BASEDIR
+    ini_get( "include_path" ) . PATH_SEPARATOR . BASEDIR
 );
 
 require_once( 'classes/base.php' );

--- a/src/exceptions/processor/externalExecution.php
+++ b/src/exceptions/processor/externalExecution.php
@@ -4,6 +4,10 @@ class plProcessorExternalExecutionException extends Exception
 {
     public function __construct( $output ) 
     {
+    	// Convert array to string if is_array
+    	if(is_array($output)) {
+    		$output = var_export($output, true);
+    	}
         parent::__construct( 'Execution of external program failed:' . "\n" . $output );
     }
 }


### PR DESCRIPTION
In order to make the `config/config.php` file more OS independent, the `PATH_SEPARATOR` constant should be used instead of the colon character (`:`).